### PR TITLE
feat: label-printer 모듈 업그레이드 (v3.1.8)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "boxhero-electron",
-  "version": "3.1.7",
+  "version": "3.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "boxhero-electron",
-      "version": "3.1.7",
+      "version": "3.1.8",
       "license": "ISC",
       "dependencies": {
         "electron-log": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "boxhero-electron",
   "type": "module",
   "productName": "BoxHero",
-  "version": "3.1.7",
+  "version": "3.1.8",
   "description": "Simple Inventory Management Solution",
   "main": ".vite/build/main.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- label-printer 바이너리 모듈 업그레이드(ZPL 압축 및 일부 프린터 오류 수정)
- 앱 버전 3.1.7 → 3.1.8

## Test plan
- [ ] macOS에서 라벨 프린터 정상 시작 확인
- [ ] Windows에서 라벨 프린터 정상 시작 확인
- [ ] 라벨 출력 기능 정상 동작 확인
- [ ] 라벨 프린터 종료 시 정상 종료 확인